### PR TITLE
Java google code style config update

### DIFF
--- a/java/google-checkstyle.xml
+++ b/java/google-checkstyle.xml
@@ -63,6 +63,9 @@
     <module name="NoLineWrap">
       <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
     </module>
+    <module name="VisibilityModifier">
+      <property name="protectedAllowed" value="true"/>
+    </module>
     <module name="EmptyBlock">
       <property name="option" value="TEXT"/>
       <property name="tokens"


### PR DESCRIPTION
added new property, it should forbid developers to put default access modifiers for fields at all and public modifiers are allowed for constants only